### PR TITLE
feat(PRO-6): update CLI for new K8s-based deployment API and real-time logs

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -134,6 +134,10 @@
       "type": "runtime"
     },
     {
+      "name": "eventsource-parser",
+      "type": "runtime"
+    },
+    {
       "name": "express",
       "type": "runtime"
     },
@@ -161,6 +165,10 @@
     },
     {
       "name": "progress-stream",
+      "type": "runtime"
+    },
+    {
+      "name": "undici",
       "type": "runtime"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -60,6 +60,8 @@ const project = new typescript.TypeScriptProject({
     'form-data',
     'express',
     'open',
+    'undici',
+    'eventsource-parser',
   ],
 
   // Development dependencies

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "cli-table3": "^0.6.5",
     "commander": "^10.0.1",
     "conf": "^13.1.0",
+    "eventsource-parser": "^3.0.3",
     "express": "^5.1.0",
     "form-data": "^4.0.2",
     "fs-extra": "^11.3.0",
@@ -72,6 +73,7 @@
     "open": "^10.1.1",
     "ora": "^5.4.1",
     "progress-stream": "^2.0.0",
+    "undici": "^7.11.0",
     "yargs": "^17.7.2"
   },
   "engines": {

--- a/src/utils/custom_agents_utils/upload.ts
+++ b/src/utils/custom_agents_utils/upload.ts
@@ -5,7 +5,7 @@ import ProgressStream from 'progress-stream';
 import { XpanderClient } from '../client';
 
 const BASE_URL = 'https://deployment-manager.xpander.ai';
-const BASE_URL_STG = 'https://deployment-manager.xpander.ai';
+const BASE_URL_STG = 'https://deployment-manager.stg.xpander.ai';
 
 export const uploadAndDeploy = async (
   deploymentSpinner: ora.Ora,

--- a/src/utils/custom_agents_utils/upload.ts
+++ b/src/utils/custom_agents_utils/upload.ts
@@ -6,6 +6,7 @@ import { XpanderClient } from '../client';
 
 const BASE_URL = 'https://deployment-manager.xpander.ai';
 const BASE_URL_STG = 'https://deployment-manager.stg.xpander.ai';
+// const BASE_URL_STG = 'http://localhost:9015'; // dont remove, for local work.
 
 export const uploadAndDeploy = async (
   deploymentSpinner: ora.Ora,
@@ -49,7 +50,7 @@ export const uploadAndDeploy = async (
     progressStream.on('progress', (progress) => {
       const percent = progress.percentage.toFixed(2);
       if (progress.percentage >= 95) {
-        deploymentSpinner.text = 'Finalizing the deployment';
+        deploymentSpinner.text = 'Finalizing image upload';
       } else {
         deploymentSpinner.text = `Upload status: ${percent}%`;
       }
@@ -73,7 +74,7 @@ export const uploadAndDeploy = async (
     }
 
     // Step 3: Apply uploaded worker
-    const applyEndpoint = `${apiURL}/${client.orgId}/registry/agents/${agentId}/custom_workers/start`;
+    const applyEndpoint = `${apiURL}/${client.orgId}/registry/agents/${agentId}/custom_workers/apply`;
 
     deploymentSpinner.text = 'Applying uploaded worker...';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,6 +2858,11 @@ etag@^1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+eventsource-parser@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.3.tgz#e9af1d40b77e6268cdcbc767321e8b9f066adea8"
+  integrity sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz"
@@ -6158,6 +6163,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@^7.11.0:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.11.0.tgz#8e13a54f62afa756666c0590c38b3866e286d0b3"
+  integrity sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==
 
 universalify@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This updates the xpander-cli to work with the new Kubernetes-based custom worker infrastructure from PR #2526.

New Upload Flow
•  Matches new deployment-manager API - uses the 3-step process: get upload URL → upload to S3 → apply worker
•  Removed chunked uploads - the old Content-Range approach is no longer needed since we're going directly to S3
•  Better progress tracking - shows upload percentage and has cleaner status messages during finalization
•  Improved error handling - logs full request/response details when uploads fail

Real-time Log Streaming
•  Server-Sent Events integration - connects to the new SSE logs endpoint that streams from S3/OpenTelemetry
•  Live log display - no more 2-second polling, logs appear immediately as they're written
•  Cleaner terminal UX - eliminates the flickering from constant spinner updates and duplicate log lines
•  Proper connection handling - uses eventsource-parser for robust SSE parsing with retry support

Dependencies
Added two packages to support the new functionality:
•  eventsource-parser (^3.0.3) - handles Server-Sent Events from the logs endpoint  
•  undici (^7.11.0) - modern HTTP client with better streaming capabilities