### PR TITLE
feat(PRO-67): migrate to agno, switch config to .env, cleanup & refactor

### DIFF
--- a/src/commands/agent/interactive/deploy.ts
+++ b/src/commands/agent/interactive/deploy.ts
@@ -1,9 +1,7 @@
-import fs from 'fs/promises';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import { XPanderConfig } from '../../../types';
 import { XpanderClient } from '../../../utils/client';
 import {
   ensureAgentIsInitialized,
@@ -11,6 +9,7 @@ import {
 } from '../../../utils/custom-agents';
 import { uploadAndDeploy } from '../../../utils/custom_agents_utils/deploymentManagement';
 import { buildAndSaveDockerImage } from '../../../utils/custom_agents_utils/docker';
+import { getXpanderConfigFromEnvFile } from '../../../utils/custom_agents_utils/generic';
 import { configureLogsCommand } from '../../logs';
 
 export async function deployAgent(
@@ -55,9 +54,7 @@ export async function deployAgent(
       return;
     }
 
-    const config: XPanderConfig = JSON.parse(
-      (await fs.readFile(`${currentDirectory}/xpander_config.json`)).toString(),
-    );
+    const config = await getXpanderConfigFromEnvFile(currentDirectory);
 
     const agent = await client.getAgent(config.agent_id);
     if (!agent) {

--- a/src/commands/agent/interactive/dev.ts
+++ b/src/commands/agent/interactive/dev.ts
@@ -1,11 +1,10 @@
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
-import fs from 'fs/promises';
 import { join } from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
-import { XPanderConfig } from '../../../types';
 import { ensureAgentIsInitialized } from '../../../utils/custom-agents';
+import { getXpanderConfigFromEnvFile } from '../../../utils/custom_agents_utils/generic';
 
 async function findPythonExecutable(): Promise<string> {
   const venv = process.env.VIRTUAL_ENV;
@@ -48,9 +47,8 @@ export async function startAgent() {
   );
   if (!isInitialized) return;
 
-  const config: XPanderConfig = JSON.parse(
-    (await fs.readFile(`${currentDirectory}/xpander_config.json`)).toString(),
-  );
+  const config = await getXpanderConfigFromEnvFile(currentDirectory);
+
   devModeSpinner.text = `Starting agent ${config.agent_id}`;
 
   try {

--- a/src/commands/agent/interactive/logs.ts
+++ b/src/commands/agent/interactive/logs.ts
@@ -1,12 +1,9 @@
-import fs from 'fs/promises';
 import chalk from 'chalk';
 import ora from 'ora';
-import { XPanderConfig } from '../../../types';
 import { XpanderClient } from '../../../utils/client';
-import { fileExists, pathIsEmpty } from '../../../utils/custom-agents';
+import { pathIsEmpty } from '../../../utils/custom-agents';
+import { getXpanderConfigFromEnvFile } from '../../../utils/custom_agents_utils/generic';
 import { streamLogs } from '../../../utils/custom_agents_utils/logs';
-
-const requiredFiles = ['xpander_config.json'];
 
 export async function getAgentLogs(client: XpanderClient) {
   console.log('\n');
@@ -24,26 +21,7 @@ export async function getAgentLogs(client: XpanderClient) {
       return;
     }
 
-    const missingFiles = await Promise.all(
-      requiredFiles.map(async (file) =>
-        !(await fileExists(`${currentDirectory}/${file}`)) ? file : null,
-      ),
-    ).then((results) =>
-      results.filter((file): file is string => file !== null),
-    );
-
-    if (missingFiles.length !== 0) {
-      logsSpinner.fail(
-        `Missing required files: ${missingFiles.join(', ')}. Re-initialize your agent.`,
-      );
-      return;
-    }
-
-    const configContent = await fs.readFile(
-      `${currentDirectory}/xpander_config.json`,
-      'utf-8',
-    );
-    const config: XPanderConfig = JSON.parse(configContent);
+    const config = await getXpanderConfigFromEnvFile(currentDirectory);
 
     const agent = await client.getAgent(config.agent_id);
     if (!agent) {

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,12 +1,11 @@
-import fs from 'fs/promises';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import { XPanderConfig } from '../types';
 import { XpanderClient, createClient } from '../utils/client';
 import { ensureAgentIsInitialized, pathIsEmpty } from '../utils/custom-agents';
 import { restartDeployment } from '../utils/custom_agents_utils/deploymentManagement';
+import { getXpanderConfigFromEnvFile } from '../utils/custom_agents_utils/generic';
 
 async function restartAgent(client: XpanderClient) {
   console.log('\n');
@@ -46,9 +45,7 @@ async function restartAgent(client: XpanderClient) {
       return;
     }
 
-    const config: XPanderConfig = JSON.parse(
-      (await fs.readFile(`${currentDirectory}/xpander_config.json`)).toString(),
-    );
+    const config = await getXpanderConfigFromEnvFile(currentDirectory);
 
     const agent = await client.getAgent(config.agent_id);
     if (!agent) {

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,12 +1,11 @@
-import fs from 'fs/promises';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import { XPanderConfig } from '../types';
 import { XpanderClient, createClient } from '../utils/client';
 import { ensureAgentIsInitialized, pathIsEmpty } from '../utils/custom-agents';
 import { stopDeployment } from '../utils/custom_agents_utils/deploymentManagement';
+import { getXpanderConfigFromEnvFile } from '../utils/custom_agents_utils/generic';
 
 async function stopAgent(client: XpanderClient) {
   console.log('\n');
@@ -46,9 +45,7 @@ async function stopAgent(client: XpanderClient) {
       return;
     }
 
-    const config: XPanderConfig = JSON.parse(
-      (await fs.readFile(`${currentDirectory}/xpander_config.json`)).toString(),
-    );
+    const config = await getXpanderConfigFromEnvFile(currentDirectory);
 
     const agent = await client.getAgent(config.agent_id);
     if (!agent) {

--- a/src/constants/deployments.ts
+++ b/src/constants/deployments.ts
@@ -1,6 +1,6 @@
 export const REQUIRED_DEPLOYMENT_FILES = [
   'requirements.txt',
   'Dockerfile',
-  'xpander_config.json',
+  '.env',
   'xpander_handler.py',
 ];

--- a/src/utils/custom_agents_utils/generic.ts
+++ b/src/utils/custom_agents_utils/generic.ts
@@ -1,0 +1,46 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { XPanderConfig } from '../../types';
+
+export const getXpanderConfigFromEnvFile = async (
+  dir: string,
+): Promise<XPanderConfig> => {
+  const envPath = path.join(dir, '.env');
+  const envContent = await fs.readFile(envPath, 'utf-8');
+
+  const envVars = Object.fromEntries(
+    envContent
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#') && line.includes('='))
+      .map((line) => {
+        const [key, ...rest] = line.split('=');
+        const value = rest
+          .join('=')
+          .trim()
+          .replace(/^['"]|['"]$/g, '');
+        return [key.trim(), value];
+      }),
+  );
+
+  const apiKey = envVars.XPANDER_API_KEY;
+  const orgId = envVars.XPANDER_ORGANIZATION_ID;
+  const agentId = envVars.XPANDER_AGENT_ID;
+
+  const missingVars = [];
+  if (!apiKey) missingVars.push('XPANDER_API_KEY');
+  if (!orgId) missingVars.push('XPANDER_ORGANIZATION_ID');
+  if (!agentId) missingVars.push('XPANDER_AGENT_ID');
+
+  if (missingVars.length > 0) {
+    throw new Error(
+      `Missing required environment variable(s): ${missingVars.join(', ')}`,
+    );
+  }
+
+  return {
+    api_key: apiKey,
+    organization_id: orgId,
+    agent_id: agentId,
+  };
+};


### PR DESCRIPTION
- Migrated agent configuration from `xpander_config.json` to `.env` file using `getXpanderConfigFromEnvFile`
- Updated all relevant commands to read config from `.env` instead of JSON
- Major cleanup and simplification in agent initialization and template logic
- Removed redundant prompts and legacy template code (now defaults to agno)
- Improved environment variable merging and error handling
- Refactored and reduced duplicated code across agent commands
- Added new utility: `utils/custom_agents_utils/generic.ts` for unified config parsing
- General codebase cleanup: removed unused code, improved prompts, clarified messages

This PR streamlines agent setup, makes config handling more robust, and prepares the codebase for future template work.