### PR TITLE
feat(PRO-181): add local execution support for agent invocation

### DIFF
--- a/src/utils/local-handler.ts
+++ b/src/utils/local-handler.ts
@@ -1,0 +1,58 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Check if xpander_handler.py exists in the current directory
+ */
+export function hasLocalHandler(): boolean {
+  const handlerPath = path.join(process.cwd(), 'xpander_handler.py');
+  return fs.existsSync(handlerPath);
+}
+
+/**
+ * Check if Python is available on the system
+ */
+export function isPythonAvailable(): boolean {
+  try {
+    // Try python3 first, then python
+    const pythonCommands = ['python3', 'python'];
+
+    for (const cmd of pythonCommands) {
+      try {
+        execSync(`${cmd} --version`, { stdio: 'ignore' });
+        return true;
+      } catch {
+        // Continue to next command
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the preferred Python command (python3 or python)
+ */
+export function getPythonCommand(): string {
+  try {
+    execSync('python3 --version', { stdio: 'ignore' });
+    return 'python3';
+  } catch {
+    try {
+      execSync('python --version', { stdio: 'ignore' });
+      return 'python';
+    } catch {
+      throw new Error('Python is not available');
+    }
+  }
+}
+
+/**
+ * Check if local handler is available and ready to use
+ */
+export function canUseLocalHandler(): boolean {
+  return hasLocalHandler() && isPythonAvailable();
+}


### PR DESCRIPTION
## Summary

This PR introduces local execution support for agent invocation in the CLI. When a local handler (`xpander_handler.py`) is present and Python is available, agent messages are processed locally with streaming output. If local execution fails or isn't available, the CLI falls back to webhook invocation.

### Changes
- Added detection logic for local handler and Python availability (`canUseLocalHandler`, `getPythonCommand`).
- Updated `invoke` command to prioritize local execution, with real-time stdout/stderr streaming.
- Improved error handling and fallback behavior: automatic switch to webhook if local execution fails.
- Enhanced user prompts and output formatting for both local and webhook invocations.
- Added examples and help text for new invocation flows.

### Files Changed
- `src/commands/agent/commands/invoke.ts` (+157, −25): Main CLI logic updates.
- `src/utils/local-handler.ts` (+58): New utility for local handler management.

---
Closes PRO-181.