### PR TITLE
feat(PRO-183): Add Nvidia NeMo support for agent creation and initialization

### DIFF
--- a/src/commands/agent/commands/new.ts
+++ b/src/commands/agent/commands/new.ts
@@ -123,7 +123,7 @@ export function registerNewCommand(agentCmd: Command): void {
           }
         }
 
-        // Handle name and deployment type prompts
+        // Handle name, deployment type, and NeMo prompts
         const prompts = [];
 
         if (!name) {
@@ -141,6 +141,22 @@ export function registerNewCommand(agentCmd: Command): void {
               if (!input.trim()) return 'Name is required';
               return true;
             },
+          });
+        }
+
+        // Add NeMo prompt for agno and agno-team frameworks
+        let useNemo = false;
+        if (
+          selectedTemplate &&
+          (selectedTemplate.id === 'agno' ||
+            selectedTemplate.id === 'agno-team') &&
+          !folder
+        ) {
+          prompts.push({
+            type: 'confirm',
+            name: 'useNemo',
+            message: 'Do you want to use Nvidia NeMo for this agent?',
+            default: false,
           });
         }
 
@@ -176,6 +192,7 @@ export function registerNewCommand(agentCmd: Command): void {
 
           if (!name) name = answers.agentName;
           if (!deploymentType) deploymentType = answers.deploymentType;
+          if (answers.useNemo !== undefined) useNemo = answers.useNemo;
 
           // Show read more link for container deployment
           if (deploymentType === 'container') {
@@ -208,6 +225,7 @@ export function registerNewCommand(agentCmd: Command): void {
         let createdAgent = await client.createAgent(
           name,
           deploymentType as 'serverless' | 'container',
+          useNemo,
         );
 
         // Update spinner on success

--- a/src/commands/agent/interactive/create.ts
+++ b/src/commands/agent/interactive/create.ts
@@ -102,6 +102,28 @@ export async function createNewAgent(client: XpanderClient) {
         const selectedTemplate = await selectTemplate();
         displayTemplateInfo(selectedTemplate);
 
+        // Check if this is an agno or agno-team template and ask about NeMo
+        let useNemo = false;
+        if (
+          selectedTemplate.id === 'agno' ||
+          selectedTemplate.id === 'agno-team'
+        ) {
+          const nemoAnswer = await inquirer.prompt([
+            {
+              type: 'confirm',
+              name: 'useNemo',
+              message: 'Do you want to use Nvidia NeMo for this agent?',
+              default: false,
+            },
+          ]);
+          useNemo = nemoAnswer.useNemo;
+
+          // Update the agent with NeMo flag if selected
+          if (useNemo) {
+            await client.updateAgent(newAgent.id, { using_nemo: true });
+          }
+        }
+
         // Initialize agent with selected template
         await initializeAgentWithTemplate(
           client,

--- a/src/constants/deployments.ts
+++ b/src/constants/deployments.ts
@@ -1,5 +1,4 @@
 export const REQUIRED_DEPLOYMENT_FILES = [
-  'requirements.txt',
   'Dockerfile',
   '.env',
   'xpander_handler.py',

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -16,6 +16,7 @@ export interface Agent {
   is_coordinate_mode: boolean;
   status: string;
   active?: boolean; // Whether the agent is active
+  using_nemo: boolean; // Whether the agent use Nvidia NeMo
   version?: number;
   config?: any;
   icon?: string; // Icon (emoji) for the agent

--- a/src/types/nemo.ts
+++ b/src/types/nemo.ts
@@ -1,8 +1,24 @@
+export type NeMoGeneral = {
+  use_uvloop: boolean;
+  telemetry: any;
+};
+
+export type NeMoWorkflow = {
+  _type: string;
+  llm_name: string;
+  verbose: boolean;
+  retry_parsing_errors: boolean;
+  max_retries: number;
+};
+
 export type NeMoLLM = {
   _type: string;
   model_name: string;
   temperature: number;
 };
+
 export type NeMoConfig = {
+  general: NeMoGeneral;
   llms: Record<string, NeMoLLM>;
+  workflow: NeMoWorkflow;
 };

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -234,6 +234,7 @@ export class XpanderClient {
         organization_id: foundAgent.organization_id || this.orgId || '',
         model_provider: foundAgent.model_provider || 'openai',
         model_name: foundAgent.model_name || 'gpt-4',
+        using_nemo: foundAgent.using_nemo || false,
         // Add other fields as needed
       };
 
@@ -284,6 +285,7 @@ export class XpanderClient {
   async createAgent(
     name: string,
     deployment_type?: 'serverless' | 'container',
+    using_nemo?: boolean,
   ): Promise<Agent> {
     try {
       if (this.orgId) {
@@ -299,6 +301,7 @@ export class XpanderClient {
       const payload = {
         name,
         ...(deployment_type ? { deployment_type } : {}),
+        ...(using_nemo !== undefined ? { using_nemo } : {}),
         ...(this.orgId ? { organization_id: this.orgId } : {}),
       };
 

--- a/src/utils/nemo.ts
+++ b/src/utils/nemo.ts
@@ -12,12 +12,25 @@ const nemoConfigFileName = 'nemo_config.yml';
 export const createNeMoConfigFile = async (agent: Agent, dir: string) => {
   const configPath = path.join(dir, nemoConfigFileName);
   const config: NeMoConfig = {
+    general: {
+      use_uvloop: true,
+      telemetry: {
+        logging: { console: { _type: 'console', level: 'CRITICAL' } },
+      },
+    },
     llms: {
       [agent.model_provider]: {
         _type: agent.model_provider,
         model_name: agent.model_name,
         temperature: 0.0,
       },
+    },
+    workflow: {
+      _type: 'xpander_nemo_agent',
+      llm_name: agent.model_provider,
+      verbose: false,
+      retry_parsing_errors: true,
+      max_retries: 3,
     },
   };
 


### PR DESCRIPTION
## Summary

This PR introduces Nvidia NeMo support to the agent creation workflow, specifically for `agno` and `agno-team` templates.

### Changes
- **Agent Creation**: Added prompt to enable NeMo for eligible templates.
- **Types**: Updated agent and NeMo type definitions to include `using_nemo` flag and config types.
- **Template Cloning**: Detects NeMo-enabled agents and uses NeMo-specific templates/folders.
- **Initialization**: Creates NeMo config file when agent is set to use NeMo.
- **Client Logic**: Passes and persists the `using_nemo` flag during agent creation and updates.
- **Interactive Mode**: Handles NeMo prompt and updates agent accordingly.
- **Constants**: Minor cleanup in deployment file requirements.

### Notes
- Only agents using `agno` or `agno-team` templates are prompted for NeMo support.
- NeMo config file is generated automatically for NeMo-enabled agents.
- No breaking changes for existing agent creation flows.