### PR TITLE
fix: remove double quotes from .env file generation

### DIFF
--- a/src/utils/template-cloner.ts
+++ b/src/utils/template-cloner.ts
@@ -142,9 +142,9 @@ export async function cloneTemplate(
     const envPath = path.join(destPath, '.env');
     const envExamplePath = path.join(destPath, '.env.example');
     const envVars: any = {
-      XPANDER_API_KEY: `"${client.apiKey}"`,
-      XPANDER_ORGANIZATION_ID: `"${client.orgId!}"`,
-      XPANDER_AGENT_ID: `"${agentId}"`,
+      XPANDER_API_KEY: client.apiKey,
+      XPANDER_ORGANIZATION_ID: client.orgId!,
+      XPANDER_AGENT_ID: agentId,
     };
 
     const existingEnv = (await fileExists(envPath))


### PR DESCRIPTION
## Summary
- Fixed `.env` file generation to write environment variables without double quotes
- Changed from `KEY="value"` format to standard `KEY=value` format

## Changes
- Removed template literal quotes wrapping in `envVars` object at [template-cloner.ts:145-147](src/utils/template-cloner.ts#L145)
- Now generates `.env` files following standard environment file conventions

## Test plan
- [ ] Test agent initialization with template and verify `.env` file format
- [ ] Confirm values are written as `KEY=value` not `KEY="value"`
- [ ] Ensure existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes surrounding quotes when writing XPANDER_* variables to .env during template cloning/merge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5abc3fd50d5fe11ba881cffa99affe48c8dc89ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->