### PR TITLE
feat: [PRO-474] implement invoke command with API, webhook, and local options

### DIFF
--- a/src/commands/agent/commands/invoke.ts
+++ b/src/commands/agent/commands/invoke.ts
@@ -325,7 +325,7 @@ Examples:
 
             const isStaging = process?.env?.IS_STG === 'true';
             const baseUrl = isStaging
-              ? 'https://api-stg.xpander.ai'
+              ? 'https://api.stg.xpander.ai'
               : 'https://api.xpander.ai';
             const apiUrl = `${baseUrl}/v1/agents/${agentId}/invoke`;
 

--- a/src/commands/agent/commands/invoke.ts
+++ b/src/commands/agent/commands/invoke.ts
@@ -314,7 +314,20 @@ Examples:
 
           try {
             const orgId = getOrganizationId(options.profile);
-            const apiUrl = `https://api.xpander.ai/v1/agents/${agentId}/invoke`;
+            if (!orgId) {
+              console.error(
+                chalk.red(
+                  'No organization ID found. Please run `xpander configure` first.',
+                ),
+              );
+              process.exit(1);
+            }
+
+            const isStaging = process?.env?.IS_STG === 'true';
+            const baseUrl = isStaging
+              ? 'https://api-stg.xpander.ai'
+              : 'https://api.xpander.ai';
+            const apiUrl = `${baseUrl}/v1/agents/${agentId}/invoke`;
 
             invokeSpinner = ora(`Invoking agent with: "${message}"...`).start();
             const startTime = Date.now();

--- a/src/commands/invoke.ts
+++ b/src/commands/invoke.ts
@@ -1,0 +1,21 @@
+import { Command } from 'commander';
+import { registerInvokeCommand } from './agent/commands/invoke';
+
+/**
+ * Configure top-level invoke command (alias for agent invoke)
+ */
+export function configureInvokeCommand(program: Command): Command {
+  // Create a temporary command group for registering invoke
+  const tempCmd = new Command();
+  registerInvokeCommand(tempCmd);
+
+  // Get the invoke command that was registered
+  const invokeCommand = tempCmd.commands.find((cmd) => cmd.name() === 'invoke');
+
+  if (invokeCommand) {
+    // Add it to the main program
+    program.addCommand(invokeCommand);
+  }
+
+  return program;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { configureConfigureCommand } from './commands/configure';
 import { configureDeployCommand } from './commands/deploy';
 import { configureDevCommand } from './commands/dev';
 import { configureInitializeCommand } from './commands/initialize';
+import { configureInvokeCommand } from './commands/invoke';
 // import { configureInterfacesCommands } from './commands/interfaces/index';
 import {
   configureLoginCommand,
@@ -190,6 +191,7 @@ async function main(): Promise<void> {
   configureDevCommand(program);
   configureLogsCommand(program);
   configureSecretsSyncCommand(program);
+  configureInvokeCommand(program); // Top-level invoke alias
   agent(program);
   nemo(program);
 

--- a/src/utils/agent-resolver.ts
+++ b/src/utils/agent-resolver.ts
@@ -132,37 +132,19 @@ export async function getAgentIdFromEnvOrSelection(
   providedAgentId?: string,
   silent: boolean = false,
 ): Promise<string | null> {
-  // Try to get agent ID from .env file first
-  let envAgentId: string | undefined;
+  // If agent ID is provided, resolve it (could be name or ID)
+  if (providedAgentId) {
+    return resolveAgentId(client, providedAgentId, silent);
+  }
+
+  // Try to get agent ID from .env file
   try {
     const config = await getXpanderConfigFromEnvFile(process.cwd());
     if (config?.agent_id) {
-      envAgentId = config.agent_id;
+      return config.agent_id;
     }
   } catch (error) {
     // No .env file or no agent_id in it
-  }
-
-  // If agent ID is provided, try to resolve it
-  if (providedAgentId) {
-    const resolvedId = await resolveAgentId(client, providedAgentId, silent);
-    // If resolution failed and we have an env agent_id, fall back to it
-    if (!resolvedId && envAgentId) {
-      if (!silent) {
-        console.log(
-          chalk.yellow(
-            '⚠ Provided agent not found, using agent from .env file',
-          ),
-        );
-      }
-      return envAgentId;
-    }
-    return resolvedId;
-  }
-
-  // No providedAgentId - use env agent_id if available
-  if (envAgentId) {
-    return envAgentId;
   }
 
   // Show interactive selection

--- a/src/utils/agent-resolver.ts
+++ b/src/utils/agent-resolver.ts
@@ -132,19 +132,37 @@ export async function getAgentIdFromEnvOrSelection(
   providedAgentId?: string,
   silent: boolean = false,
 ): Promise<string | null> {
-  // If agent ID is provided, resolve it (could be name or ID)
-  if (providedAgentId) {
-    return resolveAgentId(client, providedAgentId, silent);
-  }
-
-  // Try to get agent ID from .env file
+  // Try to get agent ID from .env file first
+  let envAgentId: string | undefined;
   try {
     const config = await getXpanderConfigFromEnvFile(process.cwd());
     if (config?.agent_id) {
-      return config.agent_id;
+      envAgentId = config.agent_id;
     }
   } catch (error) {
     // No .env file or no agent_id in it
+  }
+
+  // If agent ID is provided, try to resolve it
+  if (providedAgentId) {
+    const resolvedId = await resolveAgentId(client, providedAgentId, silent);
+    // If resolution failed and we have an env agent_id, fall back to it
+    if (!resolvedId && envAgentId) {
+      if (!silent) {
+        console.log(
+          chalk.yellow(
+            '⚠ Provided agent not found, using agent from .env file',
+          ),
+        );
+      }
+      return envAgentId;
+    }
+    return resolvedId;
+  }
+
+  // No providedAgentId - use env agent_id if available
+  if (envAgentId) {
+    return envAgentId;
   }
 
   // Show interactive selection


### PR DESCRIPTION
## Summary
This PR implements explicit invocation methods for the invoke command with API as the default, removing automatic fallbacks between methods.

## Key Changes

### 1. API Invocation (New Default)
**What**: Uses `/v1/agents/<agent-id>/invoke` REST API endpoint  
**How**: Sends `{"input": {"text": "message"}}` payload with API key and org ID headers  
**Why**: More reliable and consistent than webhook, better for production use

### 2. Explicit Invocation Options
- `--api`: API invocation (default - no flag needed)
- `--webhook`: Webhook invocation (explicit flag required)
- `--local`: Local handler invocation (explicit flag required)

### 3. Removed Fallback Logic
**Before**: Local → Webhook fallback chain  
**After**: Each method is independent, fails immediately if unavailable  
**Why**: Makes behavior predictable and errors clear

### 4. Top-Level Command Alias
**Added**: `xpander invoke` as alias for `xpander agent invoke`  
**Why**: Convenience and consistency with other top-level commands

## Files Modified
- [src/commands/agent/commands/invoke.ts](https://github.com/xpander-ai/xpander-cli/blob/dt-20251210-pro-474/src/commands/agent/commands/invoke.ts) - Updated invoke logic with three methods
- [src/commands/invoke.ts](https://github.com/xpander-ai/xpander-cli/blob/dt-20251210-pro-474/src/commands/invoke.ts) - New top-level command registration
- [src/index.ts](https://github.com/xpander-ai/xpander-cli/blob/dt-20251210-pro-474/src/index.ts) - Registered invoke command

## Examples

```bash
# API invocation (default)
xpander invoke "MyAgent" "Hello world"

# Webhook invocation (explicit)
xpander invoke --webhook "MyAgent" "Hello world"

# Local handler invocation (explicit)
xpander invoke --local "MyAgent" "Hello world"

# Also works with agent subcommand
xpander agent invoke "MyAgent" "Hello world"
```

## Breaking Changes
⚠️ **Default behavior changed**:
- Old: Local handler with webhook fallback
- New: API invocation by default

**Migration**: Add `--local` flag if you need local handler behavior

## Test plan
- [ ] Test API invocation works by default
- [ ] Test webhook invocation with --webhook flag
- [ ] Test local invocation with --local flag  
- [ ] Test top-level `xpander invoke` command
- [ ] Verify no fallbacks occur between methods
- [ ] Test with various agent types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit API (default), webhook, and local invocation modes to `agent invoke`, enhances message/agent resolution (including .env), and introduces a top‑level `xpander invoke` alias.
> 
> - **CLI – `agent invoke`**
>   - **Invocation modes**: Add explicit `--api` (default), `--webhook`, and `--local` paths; remove automatic fallbacks.
>   - **API path**: Calls `POST /v1/agents/{agentId}/invoke` with `{"input": {"text": message}}`, using `x-api-key` and `x-organization-id` headers.
>   - **Input parsing**: Add `--message`; support `.env` agent auto-detection; maintain legacy `--agent/--agent-id/--agent-name`; improved interactive prompts.
>   - **UX**: Updated help examples; show selected agent; spinners and response-time display; better JSON output extraction for local runs.
>   - **Errors**: Clear failures per mode; enhanced handling for billing (429), 401/404, and timeouts.
> - **Top-level alias**
>   - Add `xpander invoke` via `configureInvokeCommand` and register it in `src/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54f7cd6524300a17b1c7ffd0f62fc8afebaf478d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->